### PR TITLE
v0.3.0

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -16,6 +16,11 @@ def girls():
     return GIRLS
 
 
+@pytest.fixture()
+def names_long():
+    return [str(i) for i in range(11)]
+
+
 @pytest.fixture(scope="class")
 def ayto_instance():
     return AYTO(GUYS, GIRLS)

--- a/conftest.py
+++ b/conftest.py
@@ -7,16 +7,6 @@ GIRLS = ["Faith", "Gina", "Heather", "Ingrid", "Joy"]
 
 
 @pytest.fixture()
-def guys():
-    return GUYS
-
-
-@pytest.fixture()
-def girls():
-    return GIRLS
-
-
-@pytest.fixture()
 def names_long():
     return [str(i) for i in range(11)]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ dev = ["mypy>=0.991", "pytest>=7.2", "pytest-benchmark>=4.0"]
 [tool.pytest.ini_options]
 addopts = [
     "--import-mode=importlib",
-    "--benchmark-min-rounds=1",
     "--benchmark-columns=median,max,stddev,rounds",
-    "--benchmark-name=short"
+    "--benchmark-name=short",
+    "--benchmark-max-time=5",
 ]
 pythonpath = "src"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["mypy>=0.991", "pytest>=7.2"]
+dev = ["mypy>=0.991", "pytest>=7.2", "pytest-benchmark>=4.0"]
 
 [project.urls]
 "Homepage" = "https://github.com/daturkel/ayto"
@@ -36,5 +36,8 @@ dev = ["mypy>=0.991", "pytest>=7.2"]
 [tool.pytest.ini_options]
 addopts = [
     "--import-mode=importlib",
+    "--benchmark-min-rounds=1",
+    "--benchmark-columns=median,max,stddev,rounds",
+    "--benchmark-name=short"
 ]
 pythonpath = "src"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ayto"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
     { name="Dan Turkel", email="daturkel@gmail.com" }
 ]

--- a/src/ayto/ayto.py
+++ b/src/ayto/ayto.py
@@ -152,19 +152,21 @@ class AYTO:
         to calculate the probabilities until the end).
 
         """
-        counter = defaultdict(lambda: defaultdict(int))
-
-        for scenario in self._scenarios:
-            for guy, girl in enumerate(scenario):
-                counter[guy][girl] += 1
-
         self._probs = defaultdict(lambda: defaultdict(float))
 
+        # iterate over guys
         for guy_idx, guy in enumerate(self.guys):
-            total = sum(counter[guy_idx].values())
-            for girl in self.girls:
-                girl_idx = self.girl_ids[girl]
-                self._probs[guy][girl] = counter[guy_idx][girl_idx] / total
+            # get that guy's column of the scenarios dataframe
+            col = self._scenarios[:, guy_idx]
+            # construct a dictionary counting how many times each girl_idx appears (it's
+            # marginally faster than doing `count = (col == girl_idx).sum()` for each girl)
+            unique, counts = np.unique(col, return_counts=True)
+            count_dict = dict(zip(unique, counts))
+            for girl_idx, girl in enumerate(self.girls):
+                # populate probs dict with probaility = counts / num_scenarios
+                self._probs[guy][girl] = (
+                    count_dict.get(girl_idx, 0) / self.num_scenarios
+                )
 
     def save(self, path: str):
         """Save results to a file.

--- a/src/ayto/utils.py
+++ b/src/ayto/utils.py
@@ -1,0 +1,34 @@
+import numpy as np
+from math import factorial
+from numpy.typing import NDArray
+
+
+def faster_permutations(n: int) -> NDArray:
+    """Generate a numpy array of the permutations 0 to n-1.
+
+    Source: Daniel Giger's StackOverflow answer: https://stackoverflow.com/a/71231033
+
+    """
+    # empty() is fast because it does not initialize the values of the array
+    # order='F' uses Fortran ordering, which makes accessing elements in the same column fast
+    perms = np.empty((factorial(n), n), dtype=np.uint8, order="F")
+    perms[0, 0] = 0
+
+    rows_to_copy = 1
+    for i in range(1, n):
+        perms[:rows_to_copy, i] = i
+        for j in range(1, i + 1):
+            start_row = rows_to_copy * j
+            end_row = rows_to_copy * (j + 1)
+            splitter = i - j
+            perms[start_row:end_row, splitter] = i
+            perms[start_row:end_row, :splitter] = perms[
+                :rows_to_copy, :splitter
+            ]  # left side
+            perms[start_row:end_row, splitter + 1 : i + 1] = perms[
+                :rows_to_copy, splitter:i
+            ]  # right side
+
+        rows_to_copy *= i + 1
+
+    return perms

--- a/src/ayto/utils.py
+++ b/src/ayto/utils.py
@@ -6,7 +6,7 @@ from numpy.typing import NDArray
 def faster_permutations(n: int) -> NDArray:
     """Generate a numpy array of the permutations 0 to n-1.
 
-    Source: Daniel Giger's StackOverflow answer: https://stackoverflow.com/a/71231033
+    Source: Daniel Giger's Stack Overflow answer: https://stackoverflow.com/a/71231033
 
     """
     # empty() is fast because it does not initialize the values of the array

--- a/tests/test_ayto.py
+++ b/tests/test_ayto.py
@@ -30,7 +30,6 @@ class TestMatchup:
         assert num_remaining == 20
 
     def test_results(self, ayto_instance: AYTO):
-        print(ayto_instance.probabilities.values)
         assert np.allclose(
             ayto_instance.probabilities.values,
             [

--- a/tests/test_ayto.py
+++ b/tests/test_ayto.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 import numpy as np

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,29 @@
+from ayto import AYTO
+
+
+def test_benchmark_initialize(benchmark, names_long: list[str]):
+    benchmark(AYTO, names_long, names_long)
+
+
+def test_benchmark_truth_booth(benchmark, names_long: list[str]):
+    def setup():
+        ayto_instance = AYTO(names_long, names_long)
+        return ((ayto_instance,), {})
+
+    benchmark.pedantic(
+        lambda x: x.apply_truth_booth(
+            names_long[0], names_long[0], False, calc_probs=False
+        ),
+        setup=setup,
+    )
+
+
+def test_calc_probs(benchmark, names_long: list[str]):
+    def setup():
+        ayto_instance = AYTO(names_long, names_long)
+        ayto_instance.apply_truth_booth(
+            names_long[0], names_long[0], False, calc_probs=False
+        )
+        return ((ayto_instance,), {})
+
+    benchmark.pedantic(lambda x: x.calculate_probabilities(), setup=setup)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -15,6 +15,7 @@ def test_benchmark_truth_booth(benchmark, names_long: list[str]):
             names_long[0], names_long[0], False, calc_probs=False
         ),
         setup=setup,
+        rounds=5,
     )
 
 
@@ -26,4 +27,4 @@ def test_calc_probs(benchmark, names_long: list[str]):
         )
         return ((ayto_instance,), {})
 
-    benchmark.pedantic(lambda x: x.calculate_probabilities(), setup=setup)
+    benchmark.pedantic(lambda x: x.calculate_probabilities(), setup=setup, rounds=5)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ayto import AYTO
 
 


### PR DESCRIPTION
- remove unused `girls` and `guys` test fixtures
- added new `names_long` test fixture
- added benchmark tests on realistic dummy data
- replaced `itertools.permutations` with Daniel Giger's `faster_permutations` from [Stack Overflow]( https://stackoverflow.com/a/71231033), speeding up `AYTO` initialization substantially
- reimplemented `compute_probabilities` with numpy methods instead of for loops, speeding up probability computation substantially